### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
     name: Generate Java Models
     runs-on: ubuntu-latest
     needs: run-unit-tests # Ensures this job only starts after all tests have passed.
+    permissions:
+      contents: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/eth-library/data-archive-models/security/code-scanning/3](https://github.com/eth-library/data-archive-models/security/code-scanning/3)

To address the issue, we will add a `permissions` block to the `Generate Java Models` job. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the job. Since the job does not perform any write operations, we will set `contents: read` as the permission level. This ensures the job can read repository contents without inheriting unnecessary write permissions.

The changes will be made in the `.github/workflows/ci.yml` file, specifically within the `generate-java-models` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
