### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     needs: setup-build-environment # Ensures this job only starts after the environment setup is complete.
+    permissions:
+      contents: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/eth-library/data-archive-models/security/code-scanning/2](https://github.com/eth-library/data-archive-models/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `Run Unit Tests` job. This block should explicitly limit the permissions of the `GITHUB_TOKEN` to the least privileges required for the job. Since the job primarily checks out code and runs tests, it only needs `contents: read` permission.

The `permissions` block should be added under the `run-unit-tests` job definition in the `.github/workflows/ci.yml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
