### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # Job 1: Sets up the Nix build environment and validates your project's flake.nix configuration.
   # This ensures the foundational build tools (like Java, Maven) are available via Nix.


### PR DESCRIPTION
Potential fix for [https://github.com/eth-library/data-archive-models/security/code-scanning/1](https://github.com/eth-library/data-archive-models/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job or for the entire workflow. Since the jobs primarily involve code checkout, caching, and artifact uploads, the `contents: read` permission is sufficient. For jobs that upload artifacts or interact with pull requests, additional permissions (e.g., `pull-requests: write`) may be required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to define specific permissions. In this case, adding the block at the root level is recommended for simplicity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
