### PR TITLE
ci: enforce uv lock file in CI and switch Dependabot to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,10 @@ updates:
       interval: "daily" # Check for updates daily
       time: "23:15" # Time of day to check for updates
     open-pull-requests-limit: 5 # Limit the number of open pull requests for dependencies
-  # Update uv/pip (Python) dependencies
+  # Update uv (Python) dependencies
   # For full details, see official UV documentation:
   # https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependabot
-  # Note: GitHub Dependabot support for uv is still a work in progress
-  # See issue #2512: https://github.com/astral-sh/uv/issues/2512
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     allow:
       - dependency-type: "direct"
     directory: "/"                 # Location of package manifests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,10 @@ jobs:
         run: |
           # Enter the Nix development shell and run the build and publish commands
           nix develop --command bash -c '
+            # Install dependencies from lock file
+            echo "Syncing dependencies from lock file..."
+            uv sync --frozen
+
             # Build the package using Hatch (version determined by Git tags)
             echo "Building package..."
             uv build


### PR DESCRIPTION
## Summary

- Add `uv sync --frozen` before build in the `publish-to-testpypi` CI job
- Switch Dependabot from `pip` to native `uv` package ecosystem

## Motivation

Previously, CI did not install dependencies from `uv.lock` — `uv build` resolved versions directly from the specifiers in `pyproject.toml`. This meant CI could silently use different dependency versions than local development, making builds non-reproducible.

With `uv sync --frozen`, CI now uses the exact same dependency versions as local development. The `--frozen` flag ensures the build fails if `uv.lock` is out of sync with `pyproject.toml`, catching mismatches early.

Dependency upgrades are handled explicitly through Dependabot PRs rather than being picked up implicitly at build time.

## Dependabot ecosystem change

GitHub Dependabot added native `uv` ecosystem support, reaching [general availability in March 2025](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/). The previous `pip` ecosystem only updated `pyproject.toml` without touching `uv.lock`, which would break the `--frozen` workflow. The `uv` ecosystem updates both files together.

See also: [uv docs on Dependabot integration](https://docs.astral.sh/uv/guides/integration/dependabot/)